### PR TITLE
Rename Murf

### DIFF
--- a/declarations/Murf.json
+++ b/declarations/Murf.json
@@ -1,5 +1,5 @@
 {
-  "name": "Murf AI",
+  "name": "Murf",
   "documents": {
     "Terms of Service": {
       "fetch": "https://murf.ai/resources/terms_of_service/",


### PR DESCRIPTION
I think that the name of the service should be changed to `Murf` because this is the name used by the company on its legal content pages, view [Terms of Service](https://murf.ai/resources/terms_of_service/) and [Privacy Policy](https://murf.ai/resources/privacy_policy/). Actual service name `Murf AI` seems to be used for marketing purposes.

