### PR TITLE
Add Microsoft Copilot

### DIFF
--- a/declarations/Microsoft Copilot.json
+++ b/declarations/Microsoft Copilot.json
@@ -4,12 +4,14 @@
     "Terms of Service": {
       "fetch": "https://www.bing.com/new/termsofuse?setlang=en",
       "select": [
-        ".gi_lgl_tos",
-        ".gi_cp"
-      ]
+        "#page_content"
+      ],
+      "remove": [
+        ".cdx_mkt_brand"
+      ],
     },
     "Privacy Policy": {
-      "fetch": "https://privacy.microsoft.com/en-us/privacystatement",
+      "fetch": "https://privacy.microsoft.com/en-ie/privacystatement",
       "select": [
         "#MPS_ShortDescription",
         ".div_content"

--- a/declarations/Microsoft Copilot.json
+++ b/declarations/Microsoft Copilot.json
@@ -8,7 +8,7 @@
       ],
       "remove": [
         ".cdx_mkt_brand"
-      ],
+      ]
     },
     "Privacy Policy": {
       "fetch": "https://privacy.microsoft.com/en-ie/privacystatement",

--- a/declarations/Microsoft Copilot.json
+++ b/declarations/Microsoft Copilot.json
@@ -1,0 +1,19 @@
+{
+  "name": "Microsoft Copilot",
+  "documents": {
+    "Terms of Service": {
+      "fetch": "https://www.bing.com/new/termsofuse?setlang=en",
+      "select": [
+        ".gi_lgl_tos",
+        ".gi_cp"
+      ]
+    },
+    "Privacy Policy": {
+      "fetch": "https://privacy.microsoft.com/en-us/privacystatement",
+      "select": [
+        "#MPS_ShortDescription",
+        ".div_content"
+      ]
+    }
+  }
+}

--- a/declarations/Microsoft Copilot.json
+++ b/declarations/Microsoft Copilot.json
@@ -13,8 +13,18 @@
     "Privacy Policy": {
       "fetch": "https://privacy.microsoft.com/en-ie/privacystatement",
       "select": [
-        "#MPS_ShortDescription",
-        ".div_content"
+        "[role=\"main\"]"
+      ],
+      "remove": [
+        ".expand_collapse",
+        ".div_print",
+        ".nav_content",
+        ".LearnMoreNavigation",
+        ".TopNavigation",
+        ".CollectingYourInfoRightNav",
+        ".gcc_cookies",
+        "#dvGroupModules",
+        "#dvServicesAgreement"
       ]
     }
   }


### PR DESCRIPTION
This PR adds two documents for Microsoft Copilot:
- the Terms of service
- the Privacy statement.

It's a response to #121.