### PR TITLE
Update DeepSeek URLs

### DIFF
--- a/declarations/DeepSeek.json
+++ b/declarations/DeepSeek.json
@@ -2,14 +2,21 @@
   "name": "DeepSeek",
   "terms": {
     "Terms of Service": {
-      "fetch": "https://chat.deepseek.com/downloads/DeepSeek%20Terms%20of%20Use.html",
+      "fetch": "https://cdn.deepseek.com/policies/en-US/deepseek-terms-of-use.html",
       "select": [
         "#write"
       ],
       "executeClientScripts": true
     },
     "Privacy Policy": {
-      "fetch": "https://chat.deepseek.com/downloads/DeepSeek%20Privacy%20Policy.html",
+      "fetch": "https://cdn.deepseek.com/policies/en-US/deepseek-privacy-policy.html",
+      "select": [
+        "#write"
+      ],
+      "executeClientScripts": true
+    },
+    "Trackers Policy": {
+      "fetch": "https://cdn.deepseek.com/policies/en-US/cookies-policy.html",
       "select": [
         "#write"
       ],


### PR DESCRIPTION
Add DeepSeek Trackers Policy

The only other potential terms I could find are https://api-docs.deepseek.com/quick_start/pricing, as `Commercial Terms`, but there is really only pricing at this stage, no usage constraints.