### PR TITLE
Add Airon

### DIFF
--- a/declarations/Airon.json
+++ b/declarations/Airon.json
@@ -1,0 +1,19 @@
+{
+  "name": "Airon",
+  "terms": {
+    "Terms of Service": {
+      "fetch": "https://www.airon.ai/legal/terms-and-conditions",
+      "select": [
+        ".container-large"
+      ],
+      "executeClientScripts": true
+    },
+    "Privacy Policy": {
+      "fetch": "https://www.airon.ai/legal/privacy-policy",
+      "select": [
+        ".container-large"
+      ],
+      "executeClientScripts": true
+    }
+  }
+}


### PR DESCRIPTION
Continuing on my attempts to add more Swedish services, here is [Airon](https://www.airon.ai), a startup offering infrastructure for (generative) AI with a focus on power and security. Airon is for example [powering the Swedish project Svea](https://www.ai.se/en/news/ai-sweden-collaboration-openai-evaluating-unique-open-models) that creates an assistant for the public sector with 55 municipalities.