### PR TITLE
Fix Microsoft Copilot

### DIFF
--- a/declarations/Microsoft Copilot.json
+++ b/declarations/Microsoft Copilot.json
@@ -2,32 +2,13 @@
   "name": "Microsoft Copilot",
   "terms": {
     "Terms of Service": {
-      "fetch": "https://www.bing.com/new/termsofuse?setlang=en",
-      "select": [
-        "#page_content"
-      ],
-      "remove": [
-        ".cdx_mkt_brand"
-      ],
+      "fetch": "https://www.microsoft.com/en-us/microsoft-copilot/for-individuals/termsofuse",
+      "select": "main",
       "executeClientScripts": true
     },
     "Privacy Policy": {
-      "fetch": "https://privacy.microsoft.com/en-ie/privacystatement",
-      "select": [
-        ".col:nth-child(3)",
-        "#areaheading-uidda881 > .row"
-      ],
-      "remove": [
-        ".expand_collapse",
-        ".div_print",
-        ".nav_content",
-        ".LearnMoreNavigation",
-        ".TopNavigation",
-        ".CollectingYourInfoRightNav",
-        ".gcc_cookies",
-        "#dvGroupModules",
-        "#dvServicesAgreement"
-      ]
+      "fetch": "https://www.microsoft.com/en-us/privacy/privacystatement",
+      "select": "main"
     }
   }
 }


### PR DESCRIPTION
Fixes #137 and another silent issue with the [privacy policy](https://github.com/OpenTermsArchive/genai-contrib-versions/blob/main/Microsoft%20Copilot/Privacy%20Policy.md).

The links in the declaration were redirecting so I changed to the final URLs and updated the selectors for very broad ones. We can discuss whether they are too broad before merging, the side menu is included in the privacy policy.